### PR TITLE
Fix Contributing link in Readme.md

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,3 +1,3 @@
 ## Hi there! 👋
 
-For guidance on policies and workflows in this organization, refer to the [CONTRIBUTING](profile/CONTRIBUTING.md) document.
+For guidance on policies and workflows in this organization, refer to the [CONTRIBUTING](CONTRIBUTING.md) document.


### PR DESCRIPTION
`Contributing.md` is in the same folder as `Readme.md`, this change fixes the link on the landing page at https://github.com/ni/